### PR TITLE
Harden brute-force protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
-### Version 0.1.0
+## 6.1.0 - 2026-08-02
 
-This is the initial release version of this plugin.  This plugin will provide "push notification" style integration with a CakePHP 3.x app for various push related services.
+- Make the CakePHP plugin the canonical implementation and remove the runtime dependency on BruteForceShield.
+- Store all challenge values as server-keyed HMACs and never log submitted values.
+- Serialize limiter updates with inter-process locks and fail closed on storage errors.
+- Enable a cross-IP limit by default to backstop spoofed or rotating client addresses.
+
+## 0.1.0
+
+- Initial CakePHP brute-force protection component.

--- a/README.md
+++ b/README.md
@@ -1,163 +1,135 @@
 # CakePHP Brute Force Plugin
 
-[![Framework](https://img.shields.io/badge/Framework-CakePHP%204.x-orange.svg)](http://cakephp.org)
+[![Framework](https://img.shields.io/badge/Framework-CakePHP%205.x-orange.svg)](https://cakephp.org)
+[![PHP](https://img.shields.io/badge/PHP-8.2%2B-blue.svg)](https://www.php.net/)
 [![license](https://img.shields.io/github/license/ali1/cakephp-bruteforce.svg?maxAge=2592000)](/blob/master/LICENSE)
-[![Build Status](https://travis-ci.org/Ali1/cakephp-bruteforce.svg?branch=master)](https://travis-ci.org/Ali1/cakephp-bruteforce)
-[![Coverage Status](https://coveralls.io/repos/github/Ali1/cakephp-bruteforce/badge.svg?branch=master)](https://coveralls.io/github/Ali1/cakephp-bruteforce?branch=master)
 
-A CakePHP plugin for easy drop-in Brute Force Protection for your controller methods.
+A CakePHP 5 plugin providing cache-backed brute-force protection for controller actions. The limiter is implemented in
+this package; it is not a wrapper around BruteForceShield.
 
-Component Wrapper for [Ali1/BruteForceShield](https://github.com/Ali1/BruteForceShield)
+## Features
 
-### Features
-* IP address-based protection
-* Uses the Cache class to store attempts so no database installation necessary
-* Logs blocked attempts (uses CakePHP Logs)
-* Does not count re-attempts with same challenge details (e.g. if a user tries the same username/password combination a few times)
-* Can block multiple attempts at the same username earlier than the normal limit (to give users a chance to enter the correct username if they have been trying with the wrong one)
-* Can be applied in AppController::initialize for simpler set up when authentication plugins are used
-* Throws catchable exception which can optionally be caught
+- Per-client-IP and cross-IP attempt budgets
+- Optional stricter limit for repeated attempts against one field, such as a username
+- Duplicate-challenge detection, so retrying exactly the same values does not consume another attempt
+- Server-keyed HMAC-SHA256 storage for every submitted value
+- Inter-process locking around each complete cache read/check/write transaction
+- Fail-closed cache writes and lock acquisition, with critical logging
+- Alert logging for blocked attempts without submitted values
 
-### Requirements
+## Requirements
 
-* Composer
-* CakePHP 4.0+
-* PHP 7.2+
+- PHP 8.2+
+- CakePHP 5.x
+- A CakePHP cache configuration shared by all PHP workers serving the application
+- A non-empty, secret `Security.salt`
 
-### Installation
+The lock files live in PHP's system temporary directory and coordinate workers on one host. Each cache configuration
+uses a fixed pool of 256 striped locks, so rotating client addresses cannot create unbounded files. A multi-host
+deployment must put that directory on shared storage or add a distributed lock before sharing one limiter cache across
+hosts.
 
-In your CakePHP root directory: run the following command:
+## Installation
 
-```
+```sh
 composer require ali1/cakephp-bruteforce
 ```
 
-Then in your Application.php in your project root, add the following snippet:
+Load the plugin in `src/Application.php`:
 
 ```php
-// In project_root/Application.php:
-        $this->addPlugin('Bruteforce');
+$this->addPlugin('Bruteforce');
 ```
 
-or you can use the following shell command to enable to plugin in your bootstrap.php automatically:
-
-```
-bin/cake plugin load Bruteforce
-```
-
-### Basic Use
-
-Load the component:
-````php
-// in AppController.php or any controller
-
-    public function initialize(): void
-    {
-        parent::initialize();
-        $this->loadComponent('Bruteforce.Bruteforce');
-    }
-````
-
-Apply protection (`$this->Bruteforce->validate` must come before actually verifying or actioning the user submitted data)
-
-````php
-    public function login(): void
-    {
-        $config = new \Ali1\BruteForceShield\Configuration(); // see possible options below
-
-        /**
-         * @param string $name a unique string to store the data under (different $name for different uses of Brute
-     *                          force protection within the same application.
-         * @param array $data an array of data, can use $this->request->getData()
-         * @param \Ali1\BruteForceShield\Configuration|null $config options
-         * @param string $cache Cache to use (default: 'default'). Make sure to use one with a duration longer than your time window otherwise you will not be protected.
-         * @return void
-         */
-        $this->Bruteforce->validate(
-            'login',
-            ['username' => $this->request->getData('username'), 'password' => $this->request->getData('password')],
-            $config,
-            'default'          
-        );
-        
-        // the user will never get here if fails Brute Force Protection
-        // a TooManyAttemptsException will be thrown
-        // usual login code here
-    }
-````
-
-### Configuration Options
-
-The third argument for `validate` is the \Ali1\BruteForceShield\Configuration object.
-
-Instructions on configuring Brute Force Protection can be found [here](https://github.com/Ali1/BruteForceShield#configuration).
-
-### Usage
-
-#### For a method for username / password BruteForce
+Load the component in a controller:
 
 ```php
-// UsersController.php
-    public $components = ['Bruteforce.Bruteforce'];
-    
-    ...
-    
-    public function login()
-    {
-        // prior to actually verifying data
-        $bruteConfig = new \Ali1\BruteForceShield\Configuration();
-        $bruteConfig->setTotalAttemptsLimit(5);
-        $bruteConfig->setStricterLimitOnKey('username', 3); // setting a limit of 5 above, then a different limit here would mean the user has 3 chances to get the password right, but then an additional 2 chances if they try a different username
-        $bruteConfig->addUnencryptedKey('username'); // adding this would mean you could see which usernames are being attacked in your log files
-
-        $this->Bruteforce->validate(
-            'login', // unique name for this BruteForce action
-            ['username' => $this->request->getData('username'), 'password' => $this->request->getData('password')],
-            $bruteConfig
-        );
-        // rest of the login code to authorize the attempt
-    }
+public function initialize(): void
+{
+    parent::initialize();
+    $this->loadComponent('Bruteforce.Bruteforce');
+}
 ```
 
-#### Prevent URL based brute force
+## Basic use
 
-Non-form data can also be Brute Forced
-
-````php
-    /**
-     * @param string|null $hashedid
-     *
-     * @return void
-     */
-    public function publicAuthUrl(string $hashedid): void
-    {
-        try {
-            $bruteConfig = new Configuration();
-            $bruteConfig->addUnencryptedKey('hashedid');
-            $this->Bruteforce->validate(
-                'publicHash',
-                ['hashedid' => $hashedid],
-                $bruteConfig
-            );
-        } catch (\Bruteforce\Exception\TooManyAttemptsException $e) {
-            $this->Flash->error('Too many requests attempted. Please try again in a few minutes');
-            return $this->redirect('/');
-        }
-        
-        // then check if URL is actually valid
-````
-
-#### With user plugins (e.g. CakeDC/Users)
-
-Although not ideal, when using plugins that you do not wish to extend or modify, you can safely place the `validate` method in AppController.php `initialize` method, since this will run prior to user verification within the plugin.
+Call `validate()` before checking or acting on submitted credentials:
 
 ```php
-// AppController.php::initialize()
+use Bruteforce\Configuration;
 
-        $this->loadComponent('Bruteforce.Bruteforce'); // Keep above any authentication components if running on initialize (default)
-        $this->Bruteforce->validate(
-            'login', // unique name for this BruteForce action
-            ['username' => $this->request->getData('username'), 'password' => $this->request->getData('password')] // user entered data
-        );
-        // this will not affect any other action except ones containing POSTed usernames and passwords (empty challenges never get counted or blocked)
+$configuration = (new Configuration())
+    ->setTotalAttemptsLimit(60)
+    ->setStricterLimitOnKey('username', 7);
+
+$this->Bruteforce->validate(
+    'login',
+    [
+        'username' => $this->request->getData('username'),
+        'password' => $this->request->getData('password'),
+    ],
+    $configuration,
+);
+```
+
+The component throws `Bruteforce\Exception\TooManyAttemptsException` when a limit is reached or protection cannot
+safely persist the attempt.
+
+Applications upgrading from version 6.0 may temporarily keep importing
+`Ali1\BruteForceShield\Configuration`; this package provides that name as a deprecated compatibility class. New code
+should use `Bruteforce\Configuration`.
+
+## Limiter options
+
+The fifth `validate()` argument accepts additional options. For applications migrating from a local limiter whose third
+argument was an options array, the component also accepts that array directly as its third argument.
+
+| Option | Default | Meaning |
+|---|---:|---|
+| `timeWindow` | `300` | Per-IP rolling window in seconds |
+| `totalLimit` | `8` | Distinct attempts allowed per IP |
+| `stricterKey` | `null` | Field receiving a lower per-value limit |
+| `stricterLimit` | `null` | Distinct attempts allowed for `stricterKey` |
+| `globalTotalLimit` | `100` | Distinct attempts allowed across all IPs |
+| `globalStricterLimit` | per-IP value | Cross-IP limit for `stricterKey` |
+| `globalTimeWindow` | per-IP value | Cross-IP rolling window in seconds |
+| `skipGlobal` | `false` | Explicitly disable the cross-IP check for this request |
+| `challengeKeys` | all fields | Submitted fields included in duplicate and limit checks |
+| `caseInsensitiveKeys` | none | Fields lowercased before comparison, commonly usernames |
+| `cache` | component argument | CakePHP cache configuration name |
+
+The cross-IP budget is enabled by default. It is the backstop when an attacker can rotate source addresses or when a
+proxy configuration mistakenly accepts spoofed `X-Forwarded-For` values. Set an application-specific value based on
+legitimate aggregate traffic; disable it only when another trusted edge enforces an equivalent global budget.
+
+## Proxy configuration
+
+The component accepts `ServerRequest::clientIp()` only when it is a valid single IP address and otherwise falls back to
+the direct `REMOTE_ADDR`. This validation does not make an untrusted forwarding header trustworthy. If CakePHP request
+proxy trust is enabled, configure an explicit allowlist of trusted reverse-proxy addresses; never enable unrestricted
+proxy trust. Keep the global budget enabled even with a correct allowlist.
+
+## Stored and logged data
+
+Every non-empty scalar challenge value is normalized in memory and stored only as
+`HMAC-SHA256(value, Security.salt)`. The random-looking cache value is deterministic so duplicate and stricter-key
+comparisons remain efficient, but an attacker who obtains only the shared cache cannot run an offline dictionary attack
+without the server secret.
+
+Blocked-attempt logs contain the client IP, action name, limiting scope, submitted field names, and attempt count. They
+never contain submitted values. The legacy `addUnencryptedKey()` method is retained only so existing applications keep
+running; it no longer causes plaintext cache storage or logging and should be removed from application code.
+
+## URL-token protection
+
+Secret URL tokens use the same protection and must not be marked for plaintext handling:
+
+```php
+$configuration = (new Configuration())->setTotalAttemptsLimit(5);
+
+$this->Bruteforce->validate(
+    'publicAuthUrl',
+    ['hashedid' => $hashedid],
+    $configuration,
+);
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ali1/cakephp-bruteforce",
-    "description": "CakePHP Plugin for Brute Force Protection",
+    "description": "CakePHP-native brute-force protection plugin",
     "type": "cakephp-plugin",
     "keywords":[
         "cakephp",
@@ -19,7 +19,6 @@
     "require": {
         "php": "^8.2",
         "cakephp/cakephp": "^5.0",
-        "ali1/brute-force-shield": "^1.0.2",
         "ext-json": "*"
     },
     "require-dev": {
@@ -29,12 +28,14 @@
     },
     "autoload": {
         "psr-4": {
-            "Bruteforce\\": "src"
+            "Bruteforce\\": "src",
+            "Ali1\\BruteForceShield\\": "src/Compatibility"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "Bruteforce\\": "src",
+            "Ali1\\BruteForceShield\\": "src/Compatibility",
             "TestApp\\": "tests/TestApp/src/"
         }
     },

--- a/src/Compatibility/Configuration.php
+++ b/src/Compatibility/Configuration.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Ali1\BruteForceShield;
+
+use Bruteforce\Configuration as BruteforceConfiguration;
+
+/**
+ * Backwards-compatible name for applications upgrading from BruteForceShield.
+ *
+ * @deprecated Use \Bruteforce\Configuration.
+ */
+class Configuration extends BruteforceConfiguration
+{
+}

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,0 +1,169 @@
+<?php
+declare(strict_types=1);
+
+namespace Bruteforce;
+
+use InvalidArgumentException;
+
+class Configuration
+{
+    private int $timeWindow = 300;
+
+    private int $totalAttemptsLimit = 8;
+
+    private ?string $stricterLimitKey = null;
+
+    private ?int $stricterLimitAttempts = null;
+
+    /**
+     * Retained for source compatibility. Values are never stored or logged in plaintext.
+     *
+     * @var array<string>
+     */
+    public array $unencryptedKeyNames = [];
+
+    /**
+     * @return int|null
+     */
+    public function getStricterLimitAttempts(): ?int
+    {
+        return $this->stricterLimitAttempts;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStricterLimitKey(): ?string
+    {
+        return $this->stricterLimitKey;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeWindow(): int
+    {
+        return $this->timeWindow;
+    }
+
+    /**
+     * @param int $timeWindow
+     * @return static
+     */
+    public function setTimeWindow(int $timeWindow): static
+    {
+        if ($timeWindow < 1) {
+            throw new InvalidArgumentException('timeWindow must be greater than 0');
+        }
+        $this->timeWindow = $timeWindow;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotalAttemptsLimit(): int
+    {
+        return $this->totalAttemptsLimit;
+    }
+
+    /**
+     * @param int $totalAttemptsLimit
+     * @return static
+     */
+    public function setTotalAttemptsLimit(int $totalAttemptsLimit): static
+    {
+        if ($this->stricterLimitAttempts !== null && $totalAttemptsLimit <= $this->stricterLimitAttempts) {
+            throw new InvalidArgumentException(
+                'If a stricter limit on a key is set, totalAttemptsLimit must be greater',
+            );
+        }
+        $this->totalAttemptsLimit = $totalAttemptsLimit;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getUnencryptedKeyNames(): array
+    {
+        return $this->unencryptedKeyNames;
+    }
+
+    /**
+     * Retained for backwards compatibility; the plugin no longer permits plaintext storage or logging.
+     */
+    public function addUnencryptedKey(string $unencryptedKeyName): static
+    {
+        if (!in_array($unencryptedKeyName, $this->unencryptedKeyNames, true)) {
+            $this->unencryptedKeyNames[] = $unencryptedKeyName;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $unencryptedKeyName
+     * @return static
+     */
+    public function removeUnencryptedKey(string $unencryptedKeyName): static
+    {
+        $key = array_search($unencryptedKeyName, $this->unencryptedKeyNames, true);
+        if ($key !== false) {
+            unset($this->unencryptedKeyNames[$key]);
+            $this->unencryptedKeyNames = array_values($this->unencryptedKeyNames);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return static
+     */
+    public function removeAllUnencryptedKeys(): static
+    {
+        $this->unencryptedKeyNames = [];
+
+        return $this;
+    }
+
+    /**
+     * @param string $key
+     * @param int $attempts
+     * @return static
+     */
+    public function setStricterLimitOnKey(string $key, int $attempts): static
+    {
+        if ($attempts >= $this->totalAttemptsLimit) {
+            throw new InvalidArgumentException(
+                'If a stricter limit is set on a key, the limit must be fewer than totalAttemptsLimit',
+            );
+        }
+        $this->stricterLimitKey = $key;
+        $this->stricterLimitAttempts = $attempts;
+
+        return $this;
+    }
+
+    /**
+     * @return static
+     */
+    public function removeStricterLimit(): static
+    {
+        $this->stricterLimitAttempts = null;
+        $this->stricterLimitKey = null;
+
+        return $this;
+    }
+
+    /**
+     * @param string $keyName
+     * @return bool
+     */
+    public function isKeyEncrypted(string $keyName): bool
+    {
+        return true;
+    }
+}

--- a/src/Controller/Component/BruteforceComponent.php
+++ b/src/Controller/Component/BruteforceComponent.php
@@ -3,7 +3,8 @@ declare(strict_types=1);
 
 namespace Bruteforce\Controller\Component;
 
-use Ali1\BruteForceShield\Configuration;
+use Ali1\BruteForceShield\Configuration as LegacyConfiguration;
+use Bruteforce\Configuration;
 use Bruteforce\Utility\BruteforceLimiter;
 use Cake\Controller\Component;
 
@@ -12,7 +13,7 @@ class BruteforceComponent extends Component
     /**
      * @param string $name A unique name for each protected flow.
      * @param array $data Challenge data, commonly `$this->request->getData()`.
-     * @param \Ali1\BruteForceShield\Configuration|null $bruteConfig Legacy configuration object.
+     * @param \Bruteforce\Configuration|\Ali1\BruteForceShield\Configuration|array|null $bruteConfig Limiter configuration or limiter options.
      * @param string $cache Cache configuration name.
      * @param array $config Extra limiter options.
      * @return bool
@@ -20,16 +21,20 @@ class BruteforceComponent extends Component
     public function validate(
         string $name,
         array $data,
-        ?Configuration $bruteConfig = null,
+        Configuration|LegacyConfiguration|array|null $bruteConfig = null,
         string $cache = 'default',
         array $config = [],
     ): bool {
+        if (is_array($bruteConfig)) {
+            $config = $bruteConfig + $config;
+            $bruteConfig = null;
+        }
+
         $config += [
             'timeWindow' => $bruteConfig ? $bruteConfig->getTimeWindow() : 300,
             'totalLimit' => $bruteConfig ? $bruteConfig->getTotalAttemptsLimit() : 8,
             'stricterKey' => $bruteConfig ? $bruteConfig->getStricterLimitKey() : null,
             'stricterLimit' => $bruteConfig ? $bruteConfig->getStricterLimitAttempts() : null,
-            'plainKeys' => $bruteConfig ? $bruteConfig->getUnencryptedKeyNames() : [],
             'cache' => $cache,
         ];
 
@@ -59,6 +64,17 @@ class BruteforceComponent extends Component
      */
     private function clientIp(): string
     {
-        return (string)($this->getController()->getRequest()->clientIp() ?: 'noIP');
+        $request = $this->getController()->getRequest();
+        $clientIp = (string)$request->clientIp();
+        if (filter_var($clientIp, FILTER_VALIDATE_IP) !== false) {
+            return $clientIp;
+        }
+
+        $remoteIp = (string)$request->getEnv('REMOTE_ADDR');
+        if (filter_var($remoteIp, FILTER_VALIDATE_IP) !== false) {
+            return $remoteIp;
+        }
+
+        return 'noIP';
     }
 }

--- a/src/Utility/BruteforceLimiter.php
+++ b/src/Utility/BruteforceLimiter.php
@@ -6,6 +6,8 @@ namespace Bruteforce\Utility;
 use Bruteforce\Exception\TooManyAttemptsException;
 use Cake\Cache\Cache;
 use Cake\Log\Log;
+use Cake\Utility\Security;
+use Throwable;
 
 class BruteforceLimiter
 {
@@ -13,7 +15,7 @@ class BruteforceLimiter
      * Record an attempt and throw once the configured limits are exceeded.
      *
      * @param string $name The name of the guarded action.
-     * @param array<string, mixed> $data The submitted data forming the challenge.
+     * @param array<array-key, mixed> $data The submitted data forming the challenge.
      * @param string $clientIp The client IP the attempt came from.
      * @param array<string, mixed> $config Limiter config, merged over the defaults.
      * @return bool
@@ -26,9 +28,8 @@ class BruteforceLimiter
             'totalLimit' => 8,
             'stricterKey' => null,
             'stricterLimit' => null,
-            'plainKeys' => [],
             'cache' => 'default',
-            'globalTotalLimit' => null,
+            'globalTotalLimit' => 100,
             'globalStricterLimit' => null,
             'globalTimeWindow' => null,
             'skipGlobal' => false,
@@ -45,42 +46,68 @@ class BruteforceLimiter
             return true;
         }
 
-        $scopes = [
-            $this->checkScope($challenge, $config, $this->cacheKey($name, $clientIp), 'ip'),
-        ];
+        $scopeConfigs = [[
+            'config' => $config,
+            'cacheKey' => $this->cacheKey($name, $clientIp),
+            'scope' => 'ip',
+        ]];
         if (!$config['skipGlobal'] && $config['globalTotalLimit'] !== null) {
             $globalConfig = $config;
             $globalConfig['totalLimit'] = (int)$config['globalTotalLimit'];
             $globalConfig['stricterLimit'] = $config['globalStricterLimit'] ?? $config['stricterLimit'];
             $globalConfig['timeWindow'] = $config['globalTimeWindow'] ?? $config['timeWindow'];
-            $scopes[] = $this->checkScope($challenge, $globalConfig, $this->globalCacheKey($name), 'global');
-        }
-
-        foreach ($scopes as $scope) {
-            if ($scope['blocked']) {
-                Log::alert('Bruteforce blocked', [
-                    'ip' => $clientIp,
-                    'name' => $name,
-                    'scope' => $scope['scope'],
-                    'data' => $this->loggableChallenge($data, $challenge, (array)$config['plainKeys']),
-                    'attempts' => count($scope['history']['attempts']),
-                ]);
-
-                throw new TooManyAttemptsException();
-            }
-        }
-
-        foreach ($scopes as $scope) {
-            if ($scope['duplicate']) {
-                continue;
-            }
-            $history = $scope['history'];
-            $history['attempts'][] = [
-                'challenge' => $challenge,
-                'time' => time(),
+            $scopeConfigs[] = [
+                'config' => $globalConfig,
+                'cacheKey' => $this->globalCacheKey($name),
+                'scope' => 'global',
             ];
-            Cache::write($scope['cacheKey'], $history, $config['cache']);
         }
+
+        $cacheKeys = array_column($scopeConfigs, 'cacheKey');
+        $this->withLocks($cacheKeys, (string)$config['cache'], function () use (
+            $challenge,
+            $clientIp,
+            $config,
+            $name,
+            $scopeConfigs,
+        ): void {
+            $scopes = [];
+            foreach ($scopeConfigs as $scopeConfig) {
+                $scopes[] = $this->checkScope(
+                    $challenge,
+                    $scopeConfig['config'],
+                    $scopeConfig['cacheKey'],
+                    $scopeConfig['scope'],
+                );
+            }
+
+            foreach ($scopes as $scope) {
+                if ($scope['blocked']) {
+                    Log::alert('Bruteforce blocked', [
+                        'ip' => $clientIp,
+                        'name' => $name,
+                        'scope' => $scope['scope'],
+                        'fields' => array_keys($challenge),
+                        'attempts' => count($scope['history']['attempts']),
+                    ]);
+
+                    throw new TooManyAttemptsException();
+                }
+            }
+
+            $storedChallenge = $this->hashChallenge($challenge);
+            foreach ($scopes as $scope) {
+                if ($scope['duplicate']) {
+                    continue;
+                }
+                $history = $scope['history'];
+                $history['attempts'][] = [
+                    'challenge' => $storedChallenge,
+                    'time' => time(),
+                ];
+                $this->writeHistory($scope['cacheKey'], $history, (string)$config['cache']);
+            }
+        });
 
         return true;
     }
@@ -96,7 +123,11 @@ class BruteforceLimiter
      */
     private function checkScope(array $challenge, array $config, string $cacheKey, string $scope): array
     {
-        $history = Cache::read($cacheKey, $config['cache']);
+        try {
+            $history = Cache::read($cacheKey, $config['cache']);
+        } catch (Throwable $exception) {
+            $this->storageFailure('read', $cacheKey, (string)$config['cache'], $exception);
+        }
         $history = is_array($history) ? $history : ['attempts' => []];
         $oldestAllowed = time() - (int)$config['timeWindow'];
         $history['attempts'] = array_values(array_filter(
@@ -120,7 +151,7 @@ class BruteforceLimiter
             if (
                 $config['stricterKey']
                 && isset($challenge[$config['stricterKey']], $oldChallenge[$config['stricterKey']])
-                && hash_equals(
+                && $this->matchesValue(
                     (string)$challenge[$config['stricterKey']],
                     (string)$oldChallenge[$config['stricterKey']],
                 )
@@ -146,12 +177,12 @@ class BruteforceLimiter
     }
 
     /**
-     * Reduce submitted data to a sorted map of hashed, non-empty scalar values.
+     * Reduce submitted data to a sorted map of normalized, non-empty scalar values.
      *
-     * @param array<string, mixed> $data The submitted data.
+     * @param array<array-key, mixed> $data The submitted data.
      * @param array<string>|null $challengeKeys Keys to include, or null for all.
      * @param array<string> $caseInsensitiveKeys Keys to lowercase before hashing.
-     * @return array<string, string>
+     * @return array<string, string> Plaintext values held only for this request.
      */
     private function normaliseChallenge(array $data, ?array $challengeKeys, array $caseInsensitiveKeys): array
     {
@@ -177,7 +208,7 @@ class BruteforceLimiter
                 $value = strtolower($value);
             }
 
-            $challenge[$key] = hash('sha256', $value);
+            $challenge[$key] = $value;
         }
 
         ksort($challenge);
@@ -199,7 +230,7 @@ class BruteforceLimiter
         }
 
         foreach ($challenge as $key => $value) {
-            if (!isset($oldChallenge[$key]) || !hash_equals((string)$value, (string)$oldChallenge[$key])) {
+            if (!isset($oldChallenge[$key]) || !$this->matchesValue($value, (string)$oldChallenge[$key])) {
                 return false;
             }
         }
@@ -208,27 +239,126 @@ class BruteforceLimiter
     }
 
     /**
-     * Build a log-safe view of the challenge, redacting everything not explicitly allowed.
+     * Hash a challenge with a server-side secret before it reaches the cache.
      *
-     * @param array<string, mixed> $data The raw submitted data.
-     * @param array<string, string> $challenge The hashed challenge.
-     * @param array<string> $plainKeys Keys that may be logged in the clear.
+     * @param array<string, string> $challenge Normalized plaintext challenge.
      * @return array<string, string>
      */
-    private function loggableChallenge(array $data, array $challenge, array $plainKeys): array
+    private function hashChallenge(array $challenge): array
     {
-        if ($plainKeys === []) {
-            return array_fill_keys(array_keys($challenge), '[redacted]');
-        }
+        $hashKey = $this->hashKey();
 
-        $loggable = [];
         foreach ($challenge as $key => $value) {
-            $loggable[$key] = in_array($key, $plainKeys, true)
-                ? (string)($data[$key] ?? '')
-                : '[redacted]';
+            $challenge[$key] = hash_hmac('sha256', $value, $hashKey);
         }
 
-        return $loggable;
+        return $challenge;
+    }
+
+    /**
+     * Compare against current HMACs and cache entries from earlier plugin versions.
+     */
+    private function matchesValue(string $value, string $storedValue): bool
+    {
+        $hashKey = $this->hashKey();
+
+        $hmac = hash_hmac('sha256', $value, $hashKey);
+        if (hash_equals($hmac, $storedValue)) {
+            return true;
+        }
+
+        // Compatibility for the unsalted SHA-256 cache entries written by 6.0.x.
+        return preg_match('/^[a-f0-9]{64}$/D', $storedValue) === 1
+            && hash_equals(hash('sha256', $value), $storedValue);
+    }
+
+    /**
+     * Serialize the full read/check/write transaction for each scope on this host.
+     *
+     * @param array<string> $cacheKeys
+     * @param callable(): void $callback
+     */
+    private function withLocks(array $cacheKeys, string $cache, callable $callback): void
+    {
+        sort($cacheKeys, SORT_STRING);
+        $handles = [];
+
+        try {
+            foreach ($cacheKeys as $cacheKey) {
+                $cacheNamespace = substr(hash('sha256', $cache), 0, 8);
+                $lockStripe = substr(hash('sha256', $cacheKey), 0, 2);
+                $lockPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR
+                    . 'cakephp-bruteforce-' . $cacheNamespace . '-' . $lockStripe . '.lock';
+                $handle = fopen($lockPath, 'c+b');
+                if ($handle === false || !flock($handle, LOCK_EX)) {
+                    if (is_resource($handle)) {
+                        fclose($handle);
+                    }
+                    $this->storageFailure('lock', $cacheKey, $cache);
+                }
+                $handles[] = $handle;
+            }
+
+            $callback();
+        } finally {
+            foreach (array_reverse($handles) as $handle) {
+                flock($handle, LOCK_UN);
+                fclose($handle);
+            }
+        }
+    }
+
+    /**
+     * Return CakePHP's active application salt after bootstrap has consumed its config value.
+     */
+    private function hashKey(): string
+    {
+        try {
+            $hashKey = Security::getSalt();
+        } catch (Throwable $exception) {
+            $this->storageFailure('hash', '[challenge]', '[configuration]', $exception);
+        }
+
+        if ($hashKey === '') {
+            $this->storageFailure('hash', '[challenge]', '[configuration]');
+        }
+
+        return $hashKey;
+    }
+
+    /**
+     * @param array<string, mixed> $history
+     */
+    private function writeHistory(string $cacheKey, array $history, string $cache): void
+    {
+        try {
+            $written = Cache::write($cacheKey, $history, $cache);
+        } catch (Throwable $exception) {
+            $this->storageFailure('write', $cacheKey, $cache, $exception);
+        }
+
+        if (!$written) {
+            $this->storageFailure('write', $cacheKey, $cache);
+        }
+    }
+
+    /**
+     * Block the request after logging a limiter infrastructure failure.
+     */
+    private function storageFailure(
+        string $operation,
+        string $cacheKey,
+        string $cache,
+        ?Throwable $exception = null,
+    ): never {
+        Log::critical('Bruteforce protection storage failure; request blocked', [
+            'operation' => $operation,
+            'cache' => $cache,
+            'cacheKey' => $cacheKey,
+            'error' => $exception ? $exception::class : null,
+        ]);
+
+        throw new TooManyAttemptsException();
     }
 
     /**

--- a/tests/TestApp/src/Controller/BruteforceComponentTestController.php
+++ b/tests/TestApp/src/Controller/BruteforceComponentTestController.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TestApp\Controller;
 
-use Ali1\BruteForceShield\Configuration;
+use Bruteforce\Configuration;
 use Cake\Controller\Controller;
 
 /**
@@ -69,6 +69,23 @@ class BruteforceComponentTestController extends Controller
             'loginEncrypted',
             $this->getRequest()->getData(),
             $bruteConfig,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function loginArrayConfig(): void
+    {
+        $this->autoRender = false;
+        $this->Bruteforce->validate(
+            'loginArrayConfig',
+            $this->getRequest()->getData(),
+            [
+                'totalLimit' => 4,
+                'stricterKey' => 'username',
+                'stricterLimit' => 3,
+            ],
         );
     }
 

--- a/tests/TestCase/Controller/Component/BruteforceComponentTest.php
+++ b/tests/TestCase/Controller/Component/BruteforceComponentTest.php
@@ -73,6 +73,14 @@ class BruteforceComponentTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testLoginArrayConfiguration(): void
+    {
+        $this->loginTries('loginArrayConfig');
+    }
+
+    /**
      * @throws \Exception
      * @return void
      */

--- a/tests/TestCase/Utility/BruteforceLimiterTest.php
+++ b/tests/TestCase/Utility/BruteforceLimiterTest.php
@@ -1,0 +1,157 @@
+<?php
+declare(strict_types=1);
+
+namespace TestCase\Utility;
+
+use Ali1\BruteForceShield\Configuration as LegacyConfiguration;
+use Bruteforce\Configuration;
+use Bruteforce\Exception\TooManyAttemptsException;
+use Bruteforce\Utility\BruteforceLimiter;
+use Cake\Cache\Cache;
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Security;
+
+class BruteforceLimiterTest extends TestCase
+{
+    private BruteforceLimiter $limiter;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->limiter = new BruteforceLimiter();
+        Cache::clear('default');
+    }
+
+    public function testStoredChallengeUsesKeyedHmacAndNeverPlaintext(): void
+    {
+        $this->limiter->validate(
+            'hmac-test',
+            ['username' => 'admin@example.test', 'password' => 'correct horse battery staple'],
+            '192.0.2.10',
+            ['globalTotalLimit' => null],
+        );
+
+        $history = Cache::read('BruteforceData.192.0.2.10.hmac-test');
+        $stored = $history['attempts'][0]['challenge'];
+
+        $this->assertSame(
+            hash_hmac('sha256', 'correct horse battery staple', Security::getSalt()),
+            $stored['password'],
+        );
+        $this->assertNotSame('correct horse battery staple', $stored['password']);
+        $this->assertNotSame(hash('sha256', 'correct horse battery staple'), $stored['password']);
+        $this->assertStringNotContainsString('admin@example.test', serialize($history));
+    }
+
+    public function testRepeatedChallengeStillDoesNotConsumeAnotherAttempt(): void
+    {
+        $config = ['totalLimit' => 1, 'globalTotalLimit' => null];
+        $challenge = ['username' => 'Ali', 'password' => 'same-password'];
+
+        $this->assertTrue($this->limiter->validate('duplicate-test', $challenge, '192.0.2.11', $config));
+        $this->assertTrue($this->limiter->validate('duplicate-test', $challenge, '192.0.2.11', $config));
+
+        $history = Cache::read('BruteforceData.192.0.2.11.duplicate-test');
+        $this->assertCount(1, $history['attempts']);
+    }
+
+    public function testDefaultGlobalBudgetStopsRotatingAddresses(): void
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $this->assertTrue($this->limiter->validate(
+                'global-default-test',
+                ['token' => 'token-' . $i],
+                '198.51.100.' . (($i % 250) + 1),
+                ['totalLimit' => 1000],
+            ));
+        }
+
+        $this->expectException(TooManyAttemptsException::class);
+        $this->limiter->validate(
+            'global-default-test',
+            ['token' => 'blocked-token'],
+            '203.0.113.1',
+            ['totalLimit' => 1000],
+        );
+    }
+
+    public function testLegacyConfigurationNameRemainsSourceCompatible(): void
+    {
+        $configuration = (new LegacyConfiguration())
+            ->setTotalAttemptsLimit(10)
+            ->setStricterLimitOnKey('username', 5)
+            ->addUnencryptedKey('username');
+
+        $this->assertInstanceOf(Configuration::class, $configuration);
+        $this->assertSame(['username'], $configuration->getUnencryptedKeyNames());
+        $this->assertTrue($configuration->isKeyEncrypted('username'));
+    }
+
+    public function testCacheReadFailureBlocksInsteadOfFailingOpen(): void
+    {
+        $this->expectException(TooManyAttemptsException::class);
+
+        $this->limiter->validate(
+            'broken-cache-test',
+            ['password' => 'never-processed'],
+            '192.0.2.12',
+            ['cache' => 'missing-cache-configuration', 'globalTotalLimit' => null],
+        );
+    }
+
+    public function testParallelWorkersCannotPassTheConfiguredLimit(): void
+    {
+        $name = 'concurrency-' . bin2hex(random_bytes(8));
+        $processes = [];
+
+        for ($i = 0; $i < 12; $i++) {
+            $pipes = [];
+            $process = proc_open(
+                [PHP_BINARY, TESTS . 'concurrency-worker.php', $name, 'password-' . $i],
+                [
+                    ['pipe', 'r'],
+                    ['pipe', 'w'],
+                    ['pipe', 'w'],
+                ],
+                $pipes,
+            );
+            $this->assertIsResource($process);
+            fclose($pipes[0]);
+            $processes[] = [$process, $pipes];
+        }
+
+        $results = [];
+        foreach ($processes as [$process, $pipes]) {
+            $results[] = stream_get_contents($pipes[1]);
+            $errors = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            $this->assertSame(0, proc_close($process), $errors);
+        }
+
+        $this->assertSame(3, count(array_filter($results, static fn(string $result): bool => $result === 'allowed')));
+        $history = Cache::read('BruteforceData.192.0.2.99.' . $name);
+        $this->assertCount(3, $history['attempts']);
+    }
+
+    public function testRotatingAddressesUseABoundedLockPool(): void
+    {
+        $cacheNamespace = substr(hash('sha256', 'default'), 0, 8);
+        $pattern = sys_get_temp_dir() . DIRECTORY_SEPARATOR
+            . 'cakephp-bruteforce-' . $cacheNamespace . '-??.lock';
+
+        for ($i = 0; $i < 300; $i++) {
+            $this->limiter->validate(
+                'bounded-lock-test-' . $i,
+                ['password' => 'password-' . $i],
+                '198.51.100.' . ($i % 255),
+                ['globalTotalLimit' => null],
+            );
+        }
+
+        $lockFiles = glob($pattern);
+        $this->assertIsArray($lockFiles);
+        $this->assertNotEmpty($lockFiles);
+        $this->assertLessThanOrEqual(256, count($lockFiles));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
+use Cake\Utility\Security;
 
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
@@ -64,6 +65,7 @@ $cache = [
 Cache::setConfig($cache);
 
 Configure::write('debug', true);
+Security::setSalt('test-only-bruteforce-hmac-key');
 
 if (!function_exists('array_key_first')) {
     function array_key_first(array $arr)

--- a/tests/concurrency-worker.php
+++ b/tests/concurrency-worker.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+use Bruteforce\Exception\TooManyAttemptsException;
+use Bruteforce\Utility\BruteforceLimiter;
+
+require __DIR__ . '/bootstrap.php';
+
+$name = (string)($argv[1] ?? 'missing');
+$value = (string)($argv[2] ?? 'missing');
+
+try {
+    (new BruteforceLimiter())->validate(
+        $name,
+        ['password' => $value],
+        '192.0.2.99',
+        ['totalLimit' => 3, 'globalTotalLimit' => null],
+    );
+    echo 'allowed';
+} catch (TooManyAttemptsException) {
+    echo 'blocked';
+}

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1,3 +1,3 @@
 parameters:
-	autoload_files:
+	bootstrapFiles:
 		- %rootDir%/../../../tests/bootstrap.php


### PR DESCRIPTION
## What changed

- makes the CakePHP plugin the canonical limiter and removes the obsolete BruteForceShield dependency
- stores challenge values as server-keyed HMACs and redacts submitted values from logs
- adds bounded inter-process locking, a default global budget, validated client addresses, and fail-closed storage handling
- retains legacy configuration and array-option compatibility for consumer upgrades
- corrects PHP/CakePHP metadata and documentation

## Root cause

The CakePHP component had drifted into a parallel implementation with unsalted hashes, plaintext logging, non-atomic cache updates, and no default cross-IP backstop while still claiming to wrap the original engine.

## Checks

- PHPUnit: 15 tests, 201 assertions
- CakePHP PHPCS: clean
- PHPStan level 5: clean
- Composer validation and audit: clean
- real 12-process concurrency regression
- bounded 256-stripe lock-pool regression