### PR TITLE
Support HTTP 429 on CakePHP 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 6.1.1 - 2026-08-02
+
+- Return HTTP 429 on CakePHP 5.0–5.2, which do not provide CakePHP's later `TooManyRequestsException` class.
+
 ## 6.1.0 - 2026-08-02
 
 - Make the CakePHP plugin the canonical implementation and remove the runtime dependency on BruteForceShield.

--- a/src/Exception/TooManyAttemptsException.php
+++ b/src/Exception/TooManyAttemptsException.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace Bruteforce\Exception;
 
-use Cake\Http\Exception\TooManyRequestsException;
+use Cake\Http\Exception\HttpException;
 use Throwable;
 
-class TooManyAttemptsException extends TooManyRequestsException
+class TooManyAttemptsException extends HttpException
 {
+    protected int $_defaultCode = 429;
+
     /**
      * @param string|null $message The message, or null for the default wording.
      * @param int|null $code The exception code.

--- a/tests/TestCase/Utility/BruteforceLimiterTest.php
+++ b/tests/TestCase/Utility/BruteforceLimiterTest.php
@@ -99,6 +99,13 @@ class BruteforceLimiterTest extends TestCase
         );
     }
 
+    public function testBlockedExceptionCarriesHttp429WithoutNewerCakephpClass(): void
+    {
+        $exception = new TooManyAttemptsException();
+
+        $this->assertSame(429, $exception->getCode());
+    }
+
     public function testParallelWorkersCannotPassTheConfiguredLimit(): void
     {
         $name = 'concurrency-' . bin2hex(random_bytes(8));


### PR DESCRIPTION
## What changed

- makes `TooManyAttemptsException` extend CakePHP's stable `HttpException` base
- pins its HTTP status to 429 without relying on the later `TooManyRequestsException` class
- adds a status-code regression and 6.1.1 changelog entry

## Root cause

CakePHP 5.2 does not contain `Cake\Http\Exception\TooManyRequestsException`, although the plugin supports CakePHP 5. The block path therefore raised a class-loading error and returned 500 in Staffhub.

## Checks

- PHPUnit: 16 tests, 202 assertions
- CakePHP PHPCS: clean
- PHPStan level 5: clean
- reproduced through Staffhub's real form-login integration test