### PR TITLE
Configure monthly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Estate dependency-update policy: group routine minor/patch updates monthly.
+# Security updates remain immediate; major updates stay separate for deliberate review.
+version: 2
+
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "06:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 10
+    groups:
+      routine-minor-and-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "06:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 10
+    groups:
+      routine-minor-and-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- monitor Composer and GitHub Actions
- group routine minor and patch version updates into monthly PRs
- leave major updates as separate PRs for deliberate review
- retain immediate, separate security updates

Security alerts and automated security fixes have also been enabled at repository level. The configuration becomes active after this PR is merged.

WordPress repositories and Harleyst are intentionally outside the estate rollout.